### PR TITLE
Make GetColumnByTitle case insensitive by default

### DIFF
--- a/Smartsheet.Core/Entities/Sheet.cs
+++ b/Smartsheet.Core/Entities/Sheet.cs
@@ -96,9 +96,18 @@ namespace Smartsheet.Core.Entities
 			return column;
 		}
 
-		public Column GetColumnByTitle(string columnTitle)
+		public Column GetColumnByTitle(string columnTitle, bool caseSensitive = false)
 		{
-			var column = this.Columns.Where(c => c.Title.Equals(columnTitle)).FirstOrDefault();
+			Column column = null;
+
+			if (caseSensitive)
+			{
+				column = this.Columns.FirstOrDefault(c => c.Title.Equals(columnTitle));
+			}
+			else
+			{
+				column = this.Columns.FirstOrDefault(c => c.Title.ToLower().Equals(columnTitle.ToLower()));
+			}
 
 			return column;
 		}

--- a/Smartsheet.Core/Entities/Sheet.cs
+++ b/Smartsheet.Core/Entities/Sheet.cs
@@ -98,7 +98,7 @@ namespace Smartsheet.Core.Entities
 
 		public Column GetColumnByTitle(string columnTitle, bool caseSensitive = false)
 		{
-			Column column = null;
+			var column = new Column();
 
 			if (caseSensitive)
 			{


### PR DESCRIPTION
Add an optional paramenter to specify whether the column search should be case sensitive or case insensitive, and make it insensitive by default.